### PR TITLE
Querystring not being forwarded

### DIFF
--- a/lib/clean-up-event.js
+++ b/lib/clean-up-event.js
@@ -20,11 +20,11 @@ function cleanupAWSEvent(evt, options) {
       event.ip = request.clientIp;
       event.originalUrl = url.format({
         pathname: request.uri,
-        query: request.querystring
+        search: request.querystring
       });
       event.url = url.format({
         pathname: request.uri,
-        query: request.querystring
+        search: request.querystring
       });
       event.baseUrl = request.uri.slice(0, -request.uri.length);
       event.isBase64Encoded = request.body && request.body.encoding === "base64" ? true : false;


### PR DESCRIPTION
Use search instead of query when calling url.format since querystrin forwarded by cloudfront doesn't contain questionmark which prevents the querystring being added to the url and originalurl properties